### PR TITLE
Custom transforms added

### DIFF
--- a/core/custom_transforms.ts
+++ b/core/custom_transforms.ts
@@ -368,4 +368,44 @@ mozjexl.addTransform("substring", (val: Array<string> | string, startIndex: numb
   };
 });
 
+mozjexl.addTransform("padStart", (val: Array<string> | string, stringLength: number, padWith: string) => {
+  if (typeof val === "string") return val.padStart(stringLength,padWith);
+  const result: Array<string | ErrorObject> = [];
+  if (typeof val === "object" && Array.isArray(val)) {
+    val.forEach((record, idx) => {
+      if (typeof record === "string") {
+        result.push(record.padStart(stringLength,padWith));
+      } else {
+        result.push({
+          "error-103": `The value ${record} of type ${getType(record)} at index ${idx} has no method 'padStart'. <value> | padStart(<stringLength>,<padWith>) is only supported for String, Array<String>`
+        });
+      }
+    });
+    return result;
+  }
+  return {
+    "error-103": `The ${val} of type ${getType(val)} has no method 'padStart'. <value> | padStart(<stringLength>,<padWith>) is only supported for String, Array<String>`
+  };
+});
+
+mozjexl.addTransform("padEnd", (val: Array<string> | string, stringLength: number, padWith: string) => {
+  if (typeof val === "string") return val.padEnd(stringLength,padWith);
+  const result: Array<string | ErrorObject> = [];
+  if (typeof val === "object" && Array.isArray(val)) {
+    val.forEach((record, idx) => {
+      if (typeof record === "string") {
+        result.push(record.padEnd(stringLength,padWith));
+      } else {
+        result.push({
+          "error-103": `The value ${record} of type ${getType(record)} at index ${idx} has no method 'padEnd'. <value> | padEnd(<stringLength>,<padWith>) is only supported for String, Array<String>`
+        });
+      }
+    });
+    return result;
+  }
+  return {
+    "error-103": `The ${val} of type ${getType(val)} has no method 'padEnd'. <value> | padEnd(<stringLength>,<padWith>) is only supported for String, Array<String>`
+  };
+});
+
 export default mozjexl;

--- a/core/custom_transforms.ts
+++ b/core/custom_transforms.ts
@@ -145,7 +145,6 @@ mozjexl.addTransform(
     const result: Array<boolean | ErrorObject> = [];
     if (typeof val === "object" && Array.isArray(val)) {
       val.forEach((record, idx) => {
-        record = record.toString();
         if (typeof record === "string") {
           result.push(record.startsWith(char));
         } else {
@@ -169,7 +168,6 @@ mozjexl.addTransform(
     const result: Array<boolean | ErrorObject> = [];
     if (typeof val === "object" && Array.isArray(val)) {
       val.forEach((record, idx) => {
-        record = record.toString();
         if (typeof record === "string") {
           result.push(record.endsWith(char));
         } else {
@@ -191,7 +189,6 @@ mozjexl.addTransform("indexOfChar", (val: Array<string> | string, char: string) 
   const result: Array<number | ErrorObject> = [];
   if (typeof val === "object" && Array.isArray(val)) {
     val.forEach((record, idx) => {
-      record = record.toString();
       if (typeof record === "string") {
         result.push(record.indexOf(char));
       } else {
@@ -413,7 +410,6 @@ mozjexl.addTransform("parseInt", (val: Array<string> | string, radix: number = 1
   const result: Array<number | ErrorObject> = [];
   if (typeof val === "object" && Array.isArray(val)) {
     val.forEach((record, idx) => {
-      record = record.toString();
       if (typeof record === "string") {
         result.push(parseInt(record,radix));
       } else {
@@ -435,7 +431,6 @@ mozjexl.addTransform("parseFloat", (val: Array<string> | string) => {
   const result: Array<number | ErrorObject> = [];
   if (typeof val === "object" && Array.isArray(val)) {
     val.forEach((record, idx) => {
-      record = record.toString();
       if (typeof record === "string") {
         result.push(parseFloat(record));
       } else {
@@ -456,7 +451,6 @@ mozjexl.addTransform("toBoolean", (val: Array<string> | string) => {
   const result: Array<boolean | ErrorObject> = [];
   if (typeof val === "object" && Array.isArray(val)) {
     val.forEach((record, idx) => {
-      record = record.toString();
       if (typeof record === "string") {
         result.push(record === "true" ? true : false);
       } else {
@@ -477,7 +471,6 @@ mozjexl.addTransform("reverse", (val: Array<string> | string) => {
   const result: Array<string | ErrorObject> = [];
   if (typeof val === "object" && Array.isArray(val)) {
     val.forEach((record, idx) => {
-      record = record.toString();
       if (typeof record === "string") {
         result.push(record.split('').reverse().join(''));
       } else {
@@ -491,6 +484,180 @@ mozjexl.addTransform("reverse", (val: Array<string> | string) => {
   return {
     "error-103": `The ${val} of type ${getType(val)} has no method 'reverse'. <value> | reverse is only supported for String, Array<String>`
   };
+});
+
+mozjexl.addTransform("push", (val: Array<any>, item: any) => {
+  const result: Array<any | ErrorObject> = structuredClone(val);
+  if (typeof val === "object" && Array.isArray(val)) {
+    result.push(...item);
+    return result;
+  }
+  return {
+    "error-103": `The ${val} of type ${getType(val)} has no method 'push'. <value> | push(<item>) is only supported for Array<any>`
+  };
+});
+
+mozjexl.addTransform("pop", (val: Array<any>) => {
+  const result: Array<any | ErrorObject> = structuredClone(val);
+  if (typeof val === "object" && Array.isArray(val)) {
+    result.pop();
+    return result;
+  }
+  return {
+    "error-103": `The ${val} of type ${getType(val)} has no method 'pop'. <value> | pop is only supported for Array<any>`
+  };
+});
+
+mozjexl.addTransform("join", (val: Array<any>, delimiter: any) => {
+  const result: Array<any | ErrorObject> = structuredClone(val);
+  if (typeof val === "object" && Array.isArray(val)) {
+    return result.join(delimiter);
+  }
+  return {
+    "error-103": `The ${val} of type ${getType(val)} has no method 'join'. <value> | join(<delimiter>) is only supported for Array<any>`
+  };
+});
+
+mozjexl.addTransform("slice", (val: Array<any>, startIdx: number, endIdx: number) => {
+  if (typeof val === "object" && Array.isArray(val)) {
+    return val.slice(startIdx, endIdx);
+  }
+  return {
+    "error-103": `The ${val} of type ${getType(val)} has no method 'slice'. <value> | slice(<startIdx>,<endIdx>) is only supported for Array<any>`
+  };
+});
+
+mozjexl.addTransform("reverseArray", (val: Array<any>) => {
+  const result: Array<any | ErrorObject> = structuredClone(val);
+  if (typeof val === "object" && Array.isArray(val)) {
+    return result.reverse();
+  }
+  return {
+    "error-103": `The ${val} of type ${getType(val)} has no method 'reverseArray'. <value> | reverseArray is only supported for Array<any>`
+  };
+});
+
+mozjexl.addTransform("sortArray", (val: Array<any>) => {
+  const result: Array<any | ErrorObject> = structuredClone(val);
+  if (typeof val === "object" && Array.isArray(val)) {
+    return result.sort();
+  }
+  return {
+    "error-103": `The ${val} of type ${getType(val)} has no method 'sortArray'. <value> | sortArray is only supported for Array<any>`
+  };
+});
+
+// Code below is taken from here : https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/from#sequence_generator_range
+mozjexl.addTransform("range", (_val: null = null, start: number, stop: number, step: number) => {
+  return Array.from({ length: (stop - start) / step + 1 }, (_, i) => start + (i * step));
+});
+
+mozjexl.addTransform("removeDuplicates", (val: Array<any>) => {
+  const result: Array<any | ErrorObject> = structuredClone(val);
+  if (typeof val === "object" && Array.isArray(val)) {
+    return [...new Set(result)];
+  }
+  return {
+    "error-103": `The ${val} of type ${getType(val)} has no method 'removeDuplicates'. <value> | removeDuplicates is only supported for Array<any>`
+  };
+});
+
+mozjexl.addTransform("max", (val: Array<number>) => {
+  let result: number = -Infinity;
+  if (typeof val === "object" && Array.isArray(val)) {
+    val.forEach((record) => {
+      console.log(typeof record)
+      if (typeof record === "number") {
+        result = record > result ? record : result;
+        console.log(result)
+      }
+    });
+    return result;
+  }
+  return {
+    "error-103": `The ${val} of type ${getType(val)} has no method 'max'. <value> | max is only supported for Array<Number>`
+  };
+});
+
+mozjexl.addTransform("min", (val: Array<number>) => {
+  let result: number = Infinity;
+  if (typeof val === "object" && Array.isArray(val)) {
+    val.forEach((record) => {
+      console.log(typeof record)
+      if (typeof record === "number") {
+        result = record < result ? record : result;
+        console.log(result)
+      }
+    });
+    return result;
+  }
+  return {
+    "error-103": `The ${val} of type ${getType(val)} has no method 'min'. <value> | min is only supported for Array<Number>`
+  };
+});
+
+mozjexl.addTransform("keys", (val: object) => {
+  if (typeof val === "object" && !Array.isArray(val)) {
+    return Object.keys(val);
+  }
+  return {
+    "error-103": `The ${val} of type ${getType(val)} has no method 'keys'. <value> | keys is only supported for Object`
+  };
+});
+
+mozjexl.addTransform("values", (val: object) => {
+  if (typeof val === "object" && !Array.isArray(val)) {
+    return Object.values(val);
+  }
+  return {
+    "error-103": `The ${val} of type ${getType(val)} has no method 'values'. <value> | values is only supported for Object`
+  };
+});
+
+
+mozjexl.addTransform("entries", (val: object) => {
+  if (typeof val === "object" && !Array.isArray(val)) {
+    return Object.entries(val);
+  }
+  return {
+    "error-103": `The ${val} of type ${getType(val)} has no method 'entries'. <value> | entries is only supported for Object`
+  };
+});
+
+mozjexl.addTransform("has", (val: object, property: string) => {
+  if (typeof val === "object" && !Array.isArray(val)) {
+    return Object.hasOwn(val,property);
+  }
+  return {
+    "error-103": `The ${val} of type ${getType(val)} has no method 'has'. <value> | has is only supported for Object`
+  };
+});
+
+mozjexl.addTransform("delete", (val: Record<string,any>, properties: Array<string>) => {
+  const result: Record<string,any> = {};
+  if (typeof val === "object" && !Array.isArray(val)) {
+    const propertiesToKeep = new Set(Object.keys(val)).symmetricDifference(new Set(properties))
+    propertiesToKeep.forEach((property) => {
+      result[property] = val[property];
+    });
+    return result;
+  }
+  return {
+    "error-103": `The ${val} of type ${getType(val)} has no method 'delete'. <value> | delete(<properties>) is only supported for Object`
+  };
+});
+
+mozjexl.addTransform("stringify", (val: object) => {
+  if (typeof val === "object" || Array.isArray(val)) {
+    return JSON.stringify(val);
+  }
+  return {
+    "error-103": `The ${val} of type ${getType(val)} has no method 'stringify'. <value> | stringify is only supported for Object or Array`
+  };
+});
+
+mozjexl.addTransform("type", (val: object) => {
+  return getType(val);
 });
 
 export default mozjexl;

--- a/core/custom_transforms.ts
+++ b/core/custom_transforms.ts
@@ -408,4 +408,89 @@ mozjexl.addTransform("padEnd", (val: Array<string> | string, stringLength: numbe
   };
 });
 
+mozjexl.addTransform("parseInt", (val: Array<string> | string, radix: number = 10) => {
+  if (typeof val === "string") return parseInt(val,radix);
+  const result: Array<number | ErrorObject> = [];
+  if (typeof val === "object" && Array.isArray(val)) {
+    val.forEach((record, idx) => {
+      record = record.toString();
+      if (typeof record === "string") {
+        result.push(parseInt(record,radix));
+      } else {
+        result.push({
+          "error-103": `The value ${record} of type ${getType(record)} at index ${idx} has no method 'parseInt'. <value> | parseInt('<string>',<radix>) is only supported for String, Array<String>`
+        });
+      }
+    });
+    return result;
+  }
+  return {
+    "error-103": `The ${val} of type ${getType(val)} has no method 'parseInt'. <value> | parseInt('<string>',<radix>) is only supported for String, Array<String>`
+  };
+});
+
+
+mozjexl.addTransform("parseFloat", (val: Array<string> | string) => {
+  if (typeof val === "string") return parseFloat(val);
+  const result: Array<number | ErrorObject> = [];
+  if (typeof val === "object" && Array.isArray(val)) {
+    val.forEach((record, idx) => {
+      record = record.toString();
+      if (typeof record === "string") {
+        result.push(parseFloat(record));
+      } else {
+        result.push({
+          "error-103": `The value ${record} of type ${getType(record)} at index ${idx} has no method 'parseFloat'. <value> | parseFloat is only supported for String, Array<String>`
+        });
+      }
+    });
+    return result;
+  }
+  return {
+    "error-103": `The ${val} of type ${getType(val)} has no method 'parseFloat'. <value> | parseFloat is only supported for String, Array<String>`
+  };
+});
+
+mozjexl.addTransform("toBoolean", (val: Array<string> | string) => {
+  if (typeof val === "string") return val === "true" ? true : false;
+  const result: Array<boolean | ErrorObject> = [];
+  if (typeof val === "object" && Array.isArray(val)) {
+    val.forEach((record, idx) => {
+      record = record.toString();
+      if (typeof record === "string") {
+        result.push(record === "true" ? true : false);
+      } else {
+        result.push({
+          "error-103": `The value ${record} of type ${getType(record)} at index ${idx} has no method 'toBoolean'. <value> | toBoolean is only supported for String, Array<String>`
+        });
+      }
+    });
+    return result;
+  }
+  return {
+    "error-103": `The ${val} of type ${getType(val)} has no method 'toBoolean'. <value> | toBoolean is only supported for String, Array<String>`
+  };
+});
+
+mozjexl.addTransform("reverse", (val: Array<string> | string) => {
+  if (typeof val === "string") return val.split('').reverse().join('');
+  const result: Array<string | ErrorObject> = [];
+  if (typeof val === "object" && Array.isArray(val)) {
+    val.forEach((record, idx) => {
+      record = record.toString();
+      if (typeof record === "string") {
+        result.push(record.split('').reverse().join(''));
+      } else {
+        result.push({
+          "error-103": `The value ${record} of type ${getType(record)} at index ${idx} has no method 'reverse'. <value> | reverse is only supported for String, Array<String>`
+        });
+      }
+    });
+    return result;
+  }
+  return {
+    "error-103": `The ${val} of type ${getType(val)} has no method 'reverse'. <value> | reverse is only supported for String, Array<String>`
+  };
+});
+
 export default mozjexl;

--- a/server/islands/Playground/Playground.tsx
+++ b/server/islands/Playground/Playground.tsx
@@ -300,7 +300,7 @@ nameUpper : derived.nameObject.name | upper`
                         aria-label="Close"
                       ></button>
                     </div>
-                    <div class="modal-body">The transforms output is successfully copied to clipboard. You can use <code>/api/saveTransform</code> endpoint to svae these transformations and then use <code>/api/run</code> to run these transformations on other inputs.</div>
+                    <div class="modal-body">The transforms output is successfully copied to clipboard. You can use <code>/api/saveTransform</code> endpoint to save these transformations and then use <code>/api/run</code> to run these transformations on other inputs.</div>
                     <div class="modal-footer">
                       <button
                         type="button"

--- a/server/routes/index.tsx
+++ b/server/routes/index.tsx
@@ -3,110 +3,106 @@ import { Head } from "$fresh/runtime.ts";
 export default function Home() {
   return (
     <>
-    <Head>
+      <Head>
         <title>Datadance</title>
-        <meta
-          name="description"
-          content="Home page of Datadance."
-        />
+        <meta name="description" content="Home page of Datadance." />
       </Head>
-    <div>
-      <div class="container col-xxl-8 px-4 py-5">
-        <div class="row flex-lg-row-reverse align-items-center g-5 py-5">
-          <div class="col-10 col-sm-8 col-lg-6">
-            <img
-              src="/logo.png"
-              class="d-block mx-lg-auto img-fluid rounded-circle"
-              alt="Datadance"
-              width="700"
-              height="500"
-              loading="lazy"
-            ></img>
-          </div>
-          <div class="col-lg-6">
-            <h1 class="display-5 fw-bold text-body-emphasis lh-1 mb-3">
-              Jam and Glam Your JSON. Make it dance.
-            </h1>
-            <p class="lead">
-              <b>DataDance</b> is a versatile data processing package that makes
-              handling JSON transformations straightforward and efficient. Our
-              package not only accepts JSON input but also allows you to define
-              transformations using a code-like format. Simply provide your data
-              and transformation rules, and DataDance will process them to
-              deliver the desired output.
-            </p>
-            <div>
-              <button type="button" class="btn btn-outline-secondary">
-                <a
-                  href="https://github.com/yakshavingdevs/datadance"
-                  target="_blank"
-                  style={{
-                    "text-decoration": "none",
-                    "font-weight": "bold",
-                    color: "white",
-                  }}
-                >
-                  <div
+      <div>
+        <div class="container col-xxl-8 px-4 py-5">
+          <div class="row flex-lg-row-reverse align-items-center g-5 py-5">
+            <div class="col-10 col-sm-8 col-lg-6">
+              <img
+                src="/logo.png"
+                class="d-block mx-lg-auto img-fluid rounded-circle"
+                alt="Datadance"
+                width="700"
+                height="500"
+                loading="lazy"
+              ></img>
+            </div>
+            <div class="col-lg-6">
+              <h1 class="display-5 fw-bold text-body-emphasis lh-1 mb-3">
+                Jam and Glam Your JSON. Make it dance.
+              </h1>
+              <p class="lead">
+                <strong>DataDance</strong> is a versatile data processing
+                package that makes handling JSON transformations straightforward
+                and efficient. Our package accepts JSON input and allows you to
+                define transformations using a code-like format. Provide your
+                data and transformation rules, and DataDance will process them
+                to deliver the desired output.
+              </p>
+              <div>
+                <button type="button" class="btn btn-outline-secondary">
+                  <a
+                    href="https://github.com/yakshavingdevs/datadance"
+                    target="_blank"
                     style={{
-                      display: "inline-flex",
-                      alignItems: "center",
-                      gap: "5px",
-                      cursor: "pointer",
+                      "text-decoration": "none",
+                      "font-weight": "bold",
+                      color: "white",
                     }}
                   >
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="20"
-                      height="20"
-                      fill="white"
-                      class="bi bi-github"
-                      viewBox="0 0 16 16"
+                    <div
+                      style={{
+                        display: "inline-flex",
+                        alignItems: "center",
+                        gap: "5px",
+                        cursor: "pointer",
+                      }}
                     >
-                      <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8"></path>
-                    </svg>
-                    <p style={{ margin: 0, color: "white" }}>Source</p>
-                  </div>
-                </a>
-              </button>
-              &nbsp;&nbsp;
-              <button type="button" class="btn btn-outline-secondary">
-                <a
-                  href="https://docs.datadance.app/"
-                  target="_blank"
-                  style={{
-                    "text-decoration": "none",
-                    "font-weight": "bold",
-                    color: "white",
-                  }}
-                >
-                  <div
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        width="20"
+                        height="20"
+                        fill="white"
+                        class="bi bi-github"
+                        viewBox="0 0 16 16"
+                      >
+                        <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8"></path>
+                      </svg>
+                      <p style={{ margin: 0, color: "white" }}>Source</p>
+                    </div>
+                  </a>
+                </button>
+                &nbsp;&nbsp;
+                <button type="button" class="btn btn-outline-secondary">
+                  <a
+                    href="https://docs.datadance.app/"
+                    target="_blank"
                     style={{
-                      display: "inline-flex",
-                      alignItems: "center",
-                      gap: "5px",
-                      cursor: "pointer",
+                      "text-decoration": "none",
+                      "font-weight": "bold",
+                      color: "white",
                     }}
                   >
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="20"
-                      height="20"
-                      fill="white"
-                      viewBox="0 0 16 16"
+                    <div
+                      style={{
+                        display: "inline-flex",
+                        alignItems: "center",
+                        gap: "5px",
+                        cursor: "pointer",
+                      }}
                     >
-                      <path d="M0 1.75A.75.75 0 0 1 .75 1h7.5a.75.75 0 0 1 0 1.5H1.5v11h6.75a.75.75 0 0 1 0 1.5h-7.5A.75.75 0 0 1 0 14.25v-12.5zM11.5 1h2.25A2.25 2.25 0 0 1 16 3.25v9.5A2.25 2.25 0 0 1 13.75 15H11.5a.75.75 0 0 1 0-1.5h2.25c.414 0 .75-.336.75-.75v-9.5a.75.75 0 0 0-.75-.75H11.5a.75.75 0 0 1 0-1.5z" />
-                      <path d="M11 3.5a.5.5 0 0 0-1 0v9a.5.5 0 0 0 1 0v-9z" />
-                    </svg>
-                    <p style={{ margin: 0, color: "white" }}>Docs</p>
-                  </div>
-                </a>
-              </button>
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        width="20"
+                        height="20"
+                        fill="white"
+                        viewBox="0 0 16 16"
+                      >
+                        <path d="M0 1.75A.75.75 0 0 1 .75 1h7.5a.75.75 0 0 1 0 1.5H1.5v11h6.75a.75.75 0 0 1 0 1.5h-7.5A.75.75 0 0 1 0 14.25v-12.5zM11.5 1h2.25A2.25 2.25 0 0 1 16 3.25v9.5A2.25 2.25 0 0 1 13.75 15H11.5a.75.75 0 0 1 0-1.5h2.25c.414 0 .75-.336.75-.75v-9.5a.75.75 0 0 0-.75-.75H11.5a.75.75 0 0 1 0-1.5z" />
+                        <path d="M11 3.5a.5.5 0 0 0-1 0v9a.5.5 0 0 0 1 0v-9z" />
+                      </svg>
+                      <p style={{ margin: 0, color: "white" }}>Docs</p>
+                    </div>
+                  </a>
+                </button>
+              </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
-  
     </>
-    );
+  );
 }


### PR DESCRIPTION
- Added custom transforms padStart and padEnd
- Added new methods for string parseInt, parseFloat, toBoolean, reverse
- Fixed a typo when clicked on copy parsed transforms.
- Updated the description in the home page.
- Added more custom transforms :
    1. push
    2. pop
    3. join
    4. slice
    5. reverseArray
    6. sortArray
    7. range
    8. removeDuplicates
    9. max
    10. min
    11. keys
    12. values
    13. entires
    14. has
    15. delete
    16. stringify
    17. type